### PR TITLE
Look for TV when titleField and descField do not match resource fields

### DIFF
--- a/core/components/breadcrumbs/model/breadcrumbs/breadcrumbs.class.php
+++ b/core/components/breadcrumbs/model/breadcrumbs/breadcrumbs.class.php
@@ -172,12 +172,12 @@ class BreadCrumbs {
         if ($this->config['showCurrentCrumb']) {
             $titleToShow = $resource->get($this->config['titleField'])
                 ? $resource->get($this->config['titleField'])
-                : $resource->get('pagetitle');
+                : ($resource->getTVValue($this->config['titleField']) ? $resource->getTVValue($this->config['titleField']) : $resource->get('pagetitle'));
             if ($this->config['currentAsLink'] && (!$this->config['respectHidemenu'] || ($this->config['respectHidemenu'] && $resource->get('hidemenu') != 1 ))) {
 
                 $descriptionToUse = ($resource->get($this->config['descField']))
                     ? $resource->get($this->config['descField'])
-                    : $resource->get('pagetitle');
+                    : ($resource->getTVValue($this->config['descField']) ? $resource->getTVValue($this->config['descField']) : $resource->get('pagetitle'));
 
                 $this->_crumbs[] = $this->getChunk('bcTplCrumbCurrentLink',array(
                     'resource' => $this->modx->resource->get('id'),
@@ -214,11 +214,11 @@ class BreadCrumbs {
             if (($this->config['showHomeCrumb'] && $parent->get('id') != $this->modx->getOption('site_start')) || (!$this->config['showHomeCrumb'])) {
                 if (!$this->config['respectHidemenu'] || ($this->config['respectHidemenu'] && $parent->get('hidemenu') != 1)) {
                     $titleToShow = $parent->get($this->config['titleField'])
-                        ? $parent->get($this->config['titleField'])
-                        : $parent->get('pagetitle');
+    			        ? $parent->get($this->config['titleField'])
+				        : ($parent->getTVValue($this->config['titleField']) ? $parent->getTVValue($this->config['titleField']) : $parent->get('pagetitle'));
                     $descriptionToUse = $parent->get($this->config['descField'])
                         ? $parent->get($this->config['descField'])
-                        : $parent->get('pagetitle');
+                        : ($parent->getTVValue($this->config['descField']) ? $parent->getTVValue($this->config['descField']) : $parent->get('pagetitle'));
                     $this->_crumbs[] = $this->getChunk('bcTplCrumbLink',array(
                         'resource' => $parent->get('id'),
                         'description' => $descriptionToUse,


### PR DESCRIPTION
Added getTVValue() to the title and description logic: Field, TV, then pagetitle if neither exist.
