### PR TITLE
Changed the pullResource function to prevent a 500 error.

### DIFF
--- a/core/components/breadcrumbs/model/breadcrumbs/breadcrumbs.class.php
+++ b/core/components/breadcrumbs/model/breadcrumbs/breadcrumbs.class.php
@@ -246,7 +246,7 @@ class BreadCrumbs {
         $wa = array(
             'id' => $resourceId,
         );
-        if (!$this->config['pathThruUnPub']) {
+        if (!$this->config['pathThruUnPub'] && $resourceId != $this->modx->resource->get('id')) {
             $wa['published'] = true;
             $wa['deleted'] = false;
         }


### PR DESCRIPTION
Added a check for the current resource and the breadcrumbs config "pathThruUnPub". This lets you to see a unpublished page and not get a 500 error.
